### PR TITLE
Remove Felgo from Gamelogic_Minigui as a test

### DIFF
--- a/Pleb_GameLogic_MiniGui/Pleb_GameLogic_MiniGui.pro
+++ b/Pleb_GameLogic_MiniGui/Pleb_GameLogic_MiniGui.pro
@@ -1,5 +1,5 @@
 # allows to add DEPLOYMENTFOLDERS and links to the Felgo library and QtCreator auto-completion
-CONFIG += felgo
+#CONFIG += felgo
 #CONFIG += felgo-live
 
 # Joachim: Enabling is needed if we want to use our own C++ sources and Felgo live server. IT generates a bunch
@@ -11,7 +11,7 @@ CONFIG += felgo
 
 # Project identifier and version
 # More information: https://felgo.com/doc/felgo-publishing/#project-configuration
-PRODUCT_IDENTIFIER = com.yourcompany.wizardEVP.FelgoEmptyProject
+PRODUCT_IDENTIFIER = de.stuggi.hackaton.pleb_minigui
 PRODUCT_VERSION_NAME = 1.0.0
 PRODUCT_VERSION_CODE = 1
 
@@ -29,7 +29,8 @@ DEPLOYMENTFOLDERS += assetsFolder
 
 # Add more folders to ship with the application here
 
-RESOURCES += #    resources.qrc # uncomment for publishing
+RESOURCES += \ #    resources.qrc # uncomment for publishing
+    resources.qrc
 
 # NOTE: for PUBLISHING, perform the following steps:
 # 1. comment the DEPLOYMENTFOLDERS += qmlFolder line above, to avoid shipping your qml files with the application (instead they get compiled to the app binary)
@@ -42,7 +43,13 @@ RESOURCES += #    resources.qrc # uncomment for publishing
 
 
 # The .cpp file which was generated for your project. Feel free to hack it.
-SOURCES += main.cpp
+SOURCES += main.cpp \
+    ../Pleb_GameLogic_QtWrapper/Backend.cpp \
+    ../Pleb_GameLogic_QtWrapper/Game/AI/PlayerAI.cpp \
+    ../Pleb_GameLogic_QtWrapper/Game/AI/PlayerSimpleAI2.cpp \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/Game.cpp \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/GameStatistics.cpp \
+    ../Pleb_GameLogic_QtWrapper/Game/Konfiguration.cpp
 
 
 android {
@@ -80,8 +87,6 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-INCLUDEPATH += ../Pleb_GameLogic_QtWrapper
-LIBS += -L../build-Pleb_GameLogic_QtWrapper-Desktop_Qt_5_13_2_MinGW_32_bit-Debug/debug -llibPleb_GameLogic_QtWrapper
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH =
@@ -94,6 +99,17 @@ qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
-HEADERS +=
-
-DISTFILES +=
+HEADERS += \
+    ../Pleb_GameLogic_QtWrapper/BackEnd.h \
+    ../Pleb_GameLogic_QtWrapper/Game/AI/PlayerAI.h \
+    ../Pleb_GameLogic_QtWrapper/Game/AI/PlayerSimpleAI2.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/Game.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/GameResult.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/GameState.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/GameStatistics.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/Move.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/MoveSimple.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Game/MoveSimpleResults.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Global.h \
+    ../Pleb_GameLogic_QtWrapper/Game/GlobalConstants.h \
+    ../Pleb_GameLogic_QtWrapper/Game/Konfiguration.h

--- a/Pleb_GameLogic_MiniGui/ios/Project-Info.plist
+++ b/Pleb_GameLogic_MiniGui/ios/Project-Info.plist
@@ -7,17 +7,17 @@
     <key>CFBundleExecutable</key>
     <string>${EXECUTABLE_NAME}</string>
     <key>CFBundleIdentifier</key>
-    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <string>de.stuggi.hackaton.pleb_minigui</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>${PRODUCT_VERSION_NAME}</string>
+    <string>0.0.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>${PRODUCT_VERSION_CODE}</string>
+    <string>1</string>
     <key>UIStatusBarHidden</key>
     <true/>
     <key>LSRequiresIPhoneOS</key>

--- a/Pleb_GameLogic_MiniGui/main.cpp
+++ b/Pleb_GameLogic_MiniGui/main.cpp
@@ -1,7 +1,7 @@
-#include <QApplication>
-#include <FelgoApplication>
-#include <FelgoLiveClient>
+#include <QGuiApplication>
 #include <QQmlApplicationEngine>
+//#include <FelgoApplication>
+//#include <FelgoLiveClient>
 
 #include "../Pleb_GameLogic_QtWrapper/BackEnd.h"
 
@@ -9,23 +9,25 @@
 
 int main(int argc, char *argv[])
 {
- //   QGuiApplication app(argc, argv);
-    QApplication app(argc, argv);
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
-    FelgoApplication felgo;
+    QGuiApplication app(argc, argv);
+   // QApplication app(argc, argv);
+
+  //  FelgoApplication felgo;
 
     // QQmlApplicationEngine is the preferred way to start qml projects since Qt 5.2
     // if you have older projects using Qt App wizards from previous QtCreator versions than 3.1, please change them to QQmlApplicationEngine
     QQmlApplicationEngine engine;
-    felgo.initialize(&engine);
+ //   felgo.initialize(&engine);
 
     // Set an optional license key from project file
     // This does not work if using Felgo Live, only for Felgo Cloud Builds and local builds
-    felgo.setLicenseKey(PRODUCT_LICENSE_KEY);
+ //   felgo.setLicenseKey(PRODUCT_LICENSE_KEY);
 
     // use this during development
     // for PUBLISHING, use the entry point below
-    felgo.setMainQmlFileName(QStringLiteral("qml/Main.qml"));
+ //   felgo.setMainQmlFileName(QStringLiteral("qml/Main.qml"));
 
     // use this instead of the above call to avoid deployment of the qml files and compile them into the binary with qt's resource system qrc
     // this is the preferred deployment option for publishing games to the app stores, because then your qml files and js files are protected
@@ -34,9 +36,23 @@ int main(int argc, char *argv[])
     // felgo.setMainQmlFileName(QStringLiteral("qrc:/qml/Main.qml"));
 
     qmlRegisterType<BackEnd>("io.qt.examples.backend", 1, 0, "BackEnd");
-    engine.load(QUrl(felgo.mainQmlFileName()));
+ //   engine.load(QUrl(felgo.mainQmlFileName()));
+ //    FelgoLiveClient liveClient(&engine);
 
-//    FelgoLiveClient liveClient(&engine);
+ 
+ 
+     const QUrl url(QStringLiteral("qrc:/qml/Main.qml"));
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
+                     &app, [url](QObject *obj, const QUrl &objUrl) {
+        if (!obj && url == objUrl)
+            QCoreApplication::exit(-1);
+    }, Qt::QueuedConnection);
+    engine.load(url);
+
+ 
+ 
+ 
+
     return app.exec();
 
 }

--- a/Pleb_GameLogic_MiniGui/qml/Main.qml
+++ b/Pleb_GameLogic_MiniGui/qml/Main.qml
@@ -1,107 +1,70 @@
-import Felgo 3.0
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+// import Felgo 3.0
+import QtQuick 2.12
+import QtQuick.Controls 2.5
 import QtQuick.Layouts 1.11
 import io.qt.examples.backend 1.0
 
-GameWindow {
+ApplicationWindow {
     id: gameWindow
-
-    // You get free licenseKeys from https://felgo.com/licenseKey
-    // With a licenseKey you can:
-    //  * Publish your games & apps for the app stores
-    //  * Remove the Felgo Splash Screen or set a custom one (available with the Pro Licenses)
-    //  * Add plugins to monetize, analyze & improve your apps (available with the Pro Licenses)
-    //licenseKey: "<generate one from https://felgo.com/licenseKey>"
-
-    // the size of the Window can be changed at runtime by pressing Ctrl (or Cmd on Mac) + the number keys 1-8
-    // the content of the logical scene size (480x320 for landscape mode by default) gets scaled to the window size based on the scaleMode
-    // you can set this size to any resolution you would like your project to start with, most of the times the one of your main target device
-    // this resolution is for iPhone 4 & iPhone 4S
-    screenWidth: 960
-    screenHeight: 640
-
-    // sync deck with leader and set up the game
-    function showCards(){
-
-//        // Show cards and highlight current player
-//        var s = ""
-//        for (var i = 0; i < backend.getNumberPlayersMax(); i++)
-//        {
-//            if (i === backend.getActualPlayerID())
-//                s = s + "-->\tPlayer " + i + ": " + backend.getPlayerCardsText(i) + "\n";
-//            else
-//                s = s + "\tPlayer " + i + ": " + backend.getPlayerCardsText(i) + "\n";
-//        }
-//        textPlayerCards.text = s;
-
+    visible: true
+    width: 640
+    height: 480
+    title: "Pleb MiniGui"
+    
+    
+    Label {
+        text: "Hello world"
+        anchors.centerIn: parent
     }
+    
 
 
     BackEnd {
         id: backend
-		
-		// Update the card display whenever needed
-        onPlayerCardsTextChanged: showCards()
-        onPlayerCardsChanged: showCards()
-        onActualPlayerIDChanged: showCards()
-        Component.onCompleted: showCards();
-    }
-	
-	// According to Felgo, this might help with the Messages "NOTE:​ you are running a development build in Release Mode.​ However,​ 
-	// the Release mode is recommended only for publish builds that are released to the app stores and for final testing.​ 
-	// You can enable a publish build in the config.​json file in your qml folder by setting the "​stage"​ property to 
-	// "​publish"​.​ For more information see:​ https:​/​/​felgo.​net/​doc/​felgo-​publishing/​
-	// ... but unfortunately, it didnt help
-    EntityManager {
-      id: entityManager
-      entityContainer: scene
-    }
-	
-    Scene {
-        id: scene
 
-        // the "logical size" - the scene content is auto-scaled to match the GameWindow size
-        width: 480
-        height: 400
+        // Update the card display whenever needed
+        //        onPlayerCardsTextChanged: showCards()
+        //        onPlayerCardsChanged: showCards()
+        //        onActualPlayerIDChanged: showCards()
+        //        Component.onCompleted: showCards();
+    }
 
-        Rectangle {
-            anchors.fill: scene.gameWindowAnchorItem
-            color: "blue"
+
+    Rectangle {
+        anchors.fill: parent
+        color: "lightblue"
+    }
+
+    Text {
+        id: textPlayerCards
+        font.family: "Courier New"
+        text: backend.playerCardsText
+    }
+
+    GridLayout {
+        anchors.top: textPlayerCards.bottom
+        columns: 2
+
+        Text { text: "Number cards" }
+        TextField {
+            placeholderText: "1"
+            onTextChanged: backend.moveSimpleNumber = text
         }
 
+        Text { text: "Value (0..7)"  }
+        TextField {
+            placeholderText: "0"
+            onTextChanged: backend.moveSimpleValue = text
+        }
+
+        Text { text: "Resulting Description"  }
         Text {
-            id: textPlayerCards
-            font.family: "Courier New"
-            text: backend.playerCardsText
+            text: backend.moveSimpleText
         }
 
-        GridLayout {
-            id: gridPlayer
-            anchors.top: textPlayerCards.bottom
-            columns: 2
-
-            Text { text: "Number" }
-            TextField {
-                placeholderText: qsTr("3")
-                onTextChanged: backend.moveSimpleNumber = text
-            }
-
-            Text { text: "Value (0..7)"  }
-            TextField {
-                placeholderText: qsTr("2")
-                onTextChanged: backend.moveSimpleValue = text
-            }
-
-            Text { text: "Resulting Description"  }
-            Text {
-                text: backend.moveSimpleText
-            }
-
-            Button {
-                text: "Play it!"
-                onClicked: backend.playCards();
-            }
+        Button {
+            text: "Play it!"
+            onClicked: backend.playCards();
         }
     }
 }

--- a/Pleb_GameLogic_MiniGui/resources.qrc
+++ b/Pleb_GameLogic_MiniGui/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
     <qresource prefix="/">
-        <file>qml</file>
+        <file>qml/Main.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
- Application outline now based on Qt Quick application example "Stack"
- Integrated GameLogic directly as source files, no longer as external library
- Runs on iOS simulator and under macOS